### PR TITLE
CRC WR_DATA access sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mimxrt685s-pac"
-version = "0.2.3"
+version = "0.3.0"
 authors = [ "Felipe Balbi <felipe@balbi.sh>" ]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mimxrt685s-pac"
-version = "0.2.2"
+version = "0.2.3"
 authors = [ "Felipe Balbi <felipe@balbi.sh>" ]
 edition = "2021"
 license = "MIT"

--- a/patch/MIMXRT685S_cm33.yaml
+++ b/patch/MIMXRT685S_cm33.yaml
@@ -4,6 +4,7 @@ _svd: "../svd/MIMXRT685S_cm33.svd"
 
 _include:
   - "adc.yaml"
+  - "crc.yaml"
   - "dma.yaml"
   - "i2s.yaml"
   - "inputmux.yaml"

--- a/patch/crc.yaml
+++ b/patch/crc.yaml
@@ -1,4 +1,11 @@
 CRC_ENGINE:
+  MODE:
+    CRC_POLY:
+      _name: CRC_POLYNOMIAL
+      CRC_CCITT: [0, CRC-CCITT polynomial]
+      CRC16: [1, CRC16 polynomial]
+      CRC32: [2, CRC32 polynomial]
+
   _modify:
     WR_DATA:
       name: WR_DATA32

--- a/patch/crc.yaml
+++ b/patch/crc.yaml
@@ -1,0 +1,24 @@
+CRC_ENGINE:
+  _modify:
+    WR_DATA:
+      name: WR_DATA32
+      description: CRC data register, 32-bit access
+
+  _add:
+    WR_DATA16:
+      description: CRC data register, 16-bit access
+      addressOffset: 8
+      size: 16
+      resetValue: 0
+      resetMask: 0
+      access: write-only
+      alternateGroup: SUM_WR_DATA
+
+    WR_DATA8:
+      description: CRC data register, 8-bit access
+      addressOffset: 8
+      size: 8
+      resetValue: 0
+      resetMask: 0
+      access: write-only
+      alternateGroup: SUM_WR_DATA

--- a/src/crc_engine.rs
+++ b/src/crc_engine.rs
@@ -17,9 +17,19 @@ impl RegisterBlock {
     pub const fn seed(&self) -> &Seed {
         &self.seed
     }
-    #[doc = "0x08 - CRC data register"]
+    #[doc = "0x08 - CRC data register, 8-bit access"]
     #[inline(always)]
-    pub const fn wr_data(&self) -> &WrData {
+    pub const fn wr_data8(&self) -> &WrData8 {
+        unsafe { &*core::ptr::from_ref(self).cast::<u8>().add(8).cast() }
+    }
+    #[doc = "0x08 - CRC data register, 16-bit access"]
+    #[inline(always)]
+    pub const fn wr_data16(&self) -> &WrData16 {
+        unsafe { &*core::ptr::from_ref(self).cast::<u8>().add(8).cast() }
+    }
+    #[doc = "0x08 - CRC data register, 32-bit access"]
+    #[inline(always)]
+    pub const fn wr_data32(&self) -> &WrData32 {
         unsafe { &*core::ptr::from_ref(self).cast::<u8>().add(8).cast() }
     }
     #[doc = "0x08 - CRC checksum register"]
@@ -46,9 +56,21 @@ module"]
 pub type Sum = crate::Reg<sum::SumSpec>;
 #[doc = "CRC checksum register"]
 pub mod sum;
-#[doc = "WR_DATA (w) register accessor: CRC data register\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`wr_data::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@wr_data`]
+#[doc = "WR_DATA32 (w) register accessor: CRC data register, 32-bit access\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`wr_data32::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@wr_data32`]
 module"]
-#[doc(alias = "WR_DATA")]
-pub type WrData = crate::Reg<wr_data::WrDataSpec>;
-#[doc = "CRC data register"]
-pub mod wr_data;
+#[doc(alias = "WR_DATA32")]
+pub type WrData32 = crate::Reg<wr_data32::WrData32Spec>;
+#[doc = "CRC data register, 32-bit access"]
+pub mod wr_data32;
+#[doc = "WR_DATA16 (w) register accessor: CRC data register, 16-bit access\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`wr_data16::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@wr_data16`]
+module"]
+#[doc(alias = "WR_DATA16")]
+pub type WrData16 = crate::Reg<wr_data16::WrData16Spec>;
+#[doc = "CRC data register, 16-bit access"]
+pub mod wr_data16;
+#[doc = "WR_DATA8 (w) register accessor: CRC data register, 8-bit access\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`wr_data8::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@wr_data8`]
+module"]
+#[doc(alias = "WR_DATA8")]
+pub type WrData8 = crate::Reg<wr_data8::WrData8Spec>;
+#[doc = "CRC data register, 8-bit access"]
+pub mod wr_data8;

--- a/src/crc_engine/mode.rs
+++ b/src/crc_engine/mode.rs
@@ -2,10 +2,80 @@
 pub type R = crate::R<ModeSpec>;
 #[doc = "Register `MODE` writer"]
 pub type W = crate::W<ModeSpec>;
+#[doc = "CRC polynomial: 1X = CRC-32 polynomial 01 = CRC-16 polynomial 00 = CRC-CCITT polynomial\n\nValue on reset: 0"]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CrcPolynomial {
+    #[doc = "0: CRC-CCITT polynomial"]
+    CrcCcitt = 0,
+    #[doc = "1: CRC16 polynomial"]
+    Crc16 = 1,
+    #[doc = "2: CRC32 polynomial"]
+    Crc32 = 2,
+}
+impl From<CrcPolynomial> for u8 {
+    #[inline(always)]
+    fn from(variant: CrcPolynomial) -> Self {
+        variant as _
+    }
+}
+impl crate::FieldSpec for CrcPolynomial {
+    type Ux = u8;
+}
+impl crate::IsEnum for CrcPolynomial {}
 #[doc = "Field `CRC_POLY` reader - CRC polynomial: 1X = CRC-32 polynomial 01 = CRC-16 polynomial 00 = CRC-CCITT polynomial"]
-pub type CrcPolyR = crate::FieldReader;
+pub type CrcPolyR = crate::FieldReader<CrcPolynomial>;
+impl CrcPolyR {
+    #[doc = "Get enumerated values variant"]
+    #[inline(always)]
+    pub const fn variant(&self) -> Option<CrcPolynomial> {
+        match self.bits {
+            0 => Some(CrcPolynomial::CrcCcitt),
+            1 => Some(CrcPolynomial::Crc16),
+            2 => Some(CrcPolynomial::Crc32),
+            _ => None,
+        }
+    }
+    #[doc = "CRC-CCITT polynomial"]
+    #[inline(always)]
+    pub fn is_crc_ccitt(&self) -> bool {
+        *self == CrcPolynomial::CrcCcitt
+    }
+    #[doc = "CRC16 polynomial"]
+    #[inline(always)]
+    pub fn is_crc16(&self) -> bool {
+        *self == CrcPolynomial::Crc16
+    }
+    #[doc = "CRC32 polynomial"]
+    #[inline(always)]
+    pub fn is_crc32(&self) -> bool {
+        *self == CrcPolynomial::Crc32
+    }
+}
 #[doc = "Field `CRC_POLY` writer - CRC polynomial: 1X = CRC-32 polynomial 01 = CRC-16 polynomial 00 = CRC-CCITT polynomial"]
-pub type CrcPolyW<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+pub type CrcPolyW<'a, REG> = crate::FieldWriter<'a, REG, 2, CrcPolynomial>;
+impl<'a, REG> CrcPolyW<'a, REG>
+where
+    REG: crate::Writable + crate::RegisterSpec,
+    REG::Ux: From<u8>,
+{
+    #[doc = "CRC-CCITT polynomial"]
+    #[inline(always)]
+    pub fn crc_ccitt(self) -> &'a mut crate::W<REG> {
+        self.variant(CrcPolynomial::CrcCcitt)
+    }
+    #[doc = "CRC16 polynomial"]
+    #[inline(always)]
+    pub fn crc16(self) -> &'a mut crate::W<REG> {
+        self.variant(CrcPolynomial::Crc16)
+    }
+    #[doc = "CRC32 polynomial"]
+    #[inline(always)]
+    pub fn crc32(self) -> &'a mut crate::W<REG> {
+        self.variant(CrcPolynomial::Crc32)
+    }
+}
 #[doc = "Field `BIT_RVS_WR` reader - Data bit order: 1 = Bit order reverse for CRC_WR_DATA (per byte) 0 = No bit order reverse for CRC_WR_DATA (per byte)"]
 pub type BitRvsWrR = crate::BitReader;
 #[doc = "Field `BIT_RVS_WR` writer - Data bit order: 1 = Bit order reverse for CRC_WR_DATA (per byte) 0 = No bit order reverse for CRC_WR_DATA (per byte)"]

--- a/src/crc_engine/wr_data16.rs
+++ b/src/crc_engine/wr_data16.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `WR_DATA16` writer"]
+pub type W = crate::W<WrData16Spec>;
+#[cfg(feature = "debug")]
+impl core::fmt::Debug for crate::generic::Reg<WrData16Spec> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {}
+#[doc = "CRC data register, 16-bit access\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`wr_data16::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct WrData16Spec;
+impl crate::RegisterSpec for WrData16Spec {
+    type Ux = u16;
+}
+#[doc = "`write(|w| ..)` method takes [`wr_data16::W`](W) writer structure"]
+impl crate::Writable for WrData16Spec {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u16 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u16 = 0;
+}
+#[doc = "`reset()` method sets WR_DATA16 to value 0"]
+impl crate::Resettable for WrData16Spec {
+    const RESET_VALUE: u16 = 0;
+}

--- a/src/crc_engine/wr_data32.rs
+++ b/src/crc_engine/wr_data32.rs
@@ -1,9 +1,9 @@
-#[doc = "Register `WR_DATA` writer"]
-pub type W = crate::W<WrDataSpec>;
+#[doc = "Register `WR_DATA32` writer"]
+pub type W = crate::W<WrData32Spec>;
 #[doc = "Field `CRC_WR_DATA` writer - Data written to this register will be taken to perform CRC calculation with selected bit order and 1's complement pre-process. Any write size 8, 16 or 32-bit are allowed and accept back-to-back transactions."]
 pub type CrcWrDataW<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 #[cfg(feature = "debug")]
-impl core::fmt::Debug for crate::generic::Reg<WrDataSpec> {
+impl core::fmt::Debug for crate::generic::Reg<WrData32Spec> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "(not readable)")
     }
@@ -11,22 +11,22 @@ impl core::fmt::Debug for crate::generic::Reg<WrDataSpec> {
 impl W {
     #[doc = "Bits 0:31 - Data written to this register will be taken to perform CRC calculation with selected bit order and 1's complement pre-process. Any write size 8, 16 or 32-bit are allowed and accept back-to-back transactions."]
     #[inline(always)]
-    pub fn crc_wr_data(&mut self) -> CrcWrDataW<WrDataSpec> {
+    pub fn crc_wr_data(&mut self) -> CrcWrDataW<WrData32Spec> {
         CrcWrDataW::new(self, 0)
     }
 }
-#[doc = "CRC data register\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`wr_data::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct WrDataSpec;
-impl crate::RegisterSpec for WrDataSpec {
+#[doc = "CRC data register, 32-bit access\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`wr_data32::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct WrData32Spec;
+impl crate::RegisterSpec for WrData32Spec {
     type Ux = u32;
 }
-#[doc = "`write(|w| ..)` method takes [`wr_data::W`](W) writer structure"]
-impl crate::Writable for WrDataSpec {
+#[doc = "`write(|w| ..)` method takes [`wr_data32::W`](W) writer structure"]
+impl crate::Writable for WrData32Spec {
     type Safety = crate::Unsafe;
     const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
 }
-#[doc = "`reset()` method sets WR_DATA to value 0"]
-impl crate::Resettable for WrDataSpec {
+#[doc = "`reset()` method sets WR_DATA32 to value 0"]
+impl crate::Resettable for WrData32Spec {
     const RESET_VALUE: u32 = 0;
 }

--- a/src/crc_engine/wr_data8.rs
+++ b/src/crc_engine/wr_data8.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `WR_DATA8` writer"]
+pub type W = crate::W<WrData8Spec>;
+#[cfg(feature = "debug")]
+impl core::fmt::Debug for crate::generic::Reg<WrData8Spec> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {}
+#[doc = "CRC data register, 8-bit access\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`wr_data8::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct WrData8Spec;
+impl crate::RegisterSpec for WrData8Spec {
+    type Ux = u8;
+}
+#[doc = "`write(|w| ..)` method takes [`wr_data8::W`](W) writer structure"]
+impl crate::Writable for WrData8Spec {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+}
+#[doc = "`reset()` method sets WR_DATA8 to value 0"]
+impl crate::Resettable for WrData8Spec {
+    const RESET_VALUE: u8 = 0;
+}


### PR DESCRIPTION
The size of write to `WR_DATA` register tells the IP how many bits are valid for CRC calculation. Let's provide all valid size accessors to make it easy for HALs to use this register.