### PR TITLE
Make `R<Reg>` and `W<Reg>` transparent wrappers

### DIFF
--- a/src/generic/raw.rs
+++ b/src/generic/raw.rs
@@ -1,8 +1,12 @@
 use super::{marker, BitM, FieldSpec, RegisterSpec, Unsafe, Writable};
+
+#[repr(transparent)]
 pub struct R<REG: RegisterSpec> {
     pub(crate) bits: REG::Ux,
     pub(super) _reg: marker::PhantomData<REG>,
 }
+
+#[repr(transparent)]
 pub struct W<REG: RegisterSpec> {
     #[doc = "Writable bits"]
     pub(crate) bits: REG::Ux,


### PR DESCRIPTION
This allows unsafe code to soundly transmute the raw integer type to the wrapper. This can be useful for inline assembly outside of the PAC to return register values.

For example, I want to use this in `embassy-imxrt` to return the value of the FlexSPI `INTR` register from inline-assembly.